### PR TITLE
Use consistent reads

### DIFF
--- a/dynamo.go
+++ b/dynamo.go
@@ -91,6 +91,7 @@ func (d *DynamoDBLockClient) dynamoHasLock() (bool, error) {
 	}
 
 	params := &dynamodb.ScanInput{
+		ConsistentRead:            aws.Bool(true),
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
 		FilterExpression:          expr.Filter(),


### PR DESCRIPTION
I've probably missed out on something, but it seems that dynamodb-lock-client-golang isn't using consistent reads. This changes introduces consistent reads.

For reference, the original Java dynamodb-lock-client has used consistent reads since its very first commit.